### PR TITLE
Make credential properties public constants

### DIFF
--- a/Sources/URLRequest+AWS/URLRequest+AWS.swift
+++ b/Sources/URLRequest+AWS/URLRequest+AWS.swift
@@ -2,9 +2,9 @@ import CommonCrypto
 import Foundation
 
 public struct Credentials: Codable {
-    var accessKey: String
+    public let accessKey: String
 
-    var accessKeyID: String
+    public let accessKeyID: String
 
     fileprivate var prefixedKey: String {
         "AWS4" + accessKey


### PR DESCRIPTION
Hey, thank you very much for the extension 🙂 

Using it as a package, only the Codable initialiser is available, since the properties are not public.
Can we adjust this or is that intended behaviour?

Also, I think we can make them constants since they're never modified.